### PR TITLE
Add ability to store preview media in cloud storage

### DIFF
--- a/frontend/src/app/modules/video/components/video.component.ts
+++ b/frontend/src/app/modules/video/components/video.component.ts
@@ -344,7 +344,7 @@ export class VideoComponent implements OnInit {
         url = this.sanitizer.bypassSecurityTrustResourceUrl(this.yt_url + video.generated_video)
         type = 'youtube'
       } else {
-        url = this.drive_url + video.generated_video
+        url = video.generated_video
         type = 'drive'
       }     
 

--- a/frontend/src/app/modules/video/views/video.component.html
+++ b/frontend/src/app/modules/video/views/video.component.html
@@ -69,7 +69,7 @@
         <ng-container matColumnDef="download">
           <mat-header-cell *matHeaderCellDef> Download </mat-header-cell>
           <mat-cell *matCellDef="let element">
-            <a [href]="drive_url + element.generated_video" *ngIf="element.generated_video && element.status == 'Done'">
+            <a [href]="element.generated_video" *ngIf="element.generated_video && element.status == 'Done'">
               <mat-icon aria-hidden="false" aria-label="download icon">download</mat-icon>
             </a>
           </mat-cell>

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -29,6 +29,8 @@ export const environment = {
   scopes: "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/devstorage.read_only",
   drive_file_prefix: 'https://drive.google.com/u/0/uc?export=download&id=',
   youtube_prefix: 'https://www.youtube.com/embed/',
+  gsutil_uri_prefix: 'gs://',
+  gcs_url_prefix: 'https://storage.cloud.google.com/',
 
   sheet_id: 'sheet_id',
 

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,17 @@ else
   export SPREADSHEET_ID
 fi
 
+echo -n "Enter Google Cloud Storage bucket name to store generated assets in Google Cloud Storage instead of Google Drive (Leave blank to default to Google Drive Storage): "
+read -r GCS_BUCKET_NAME
+
+if [ -z "$GCS_BUCKET_NAME" ]
+then
+  export GCS_BUCKET_NAME=""
+else 
+  export GCS_BUCKET_NAME
+fi
+
+
 cd frontend
 sh install-cloud.sh
 cd ../
@@ -89,3 +100,4 @@ echo -e "$INSTRUCTIONS"
 echo "Your application was installed successfully! To login go to:"
 echo -e "\n${BLUE}$APP_URL/${NC}\n"
 echo -e "Sheet Id: $SPREADSHEET_ID"
+echo -e "Google Cloud Storage bucket name: $GCS_BUCKET_NAME"

--- a/video-generator/install-cloud.sh
+++ b/video-generator/install-cloud.sh
@@ -82,8 +82,9 @@ docker push "$IMAGE_NAME"
 echo 'Apply application to cluster...'
 
 echo -e "Sheet Id inside container shoud be: $SPREADSHEET_ID"
+echo -e "Google Cloud Storage bucket Name inside container shoud be: $GCS_BUCKET_NAME"
 
-# ENV vars needed: IMAGE_NAME, SPREADSHEET_ID
+# ENV vars needed: IMAGE_NAME, SPREADSHEET_ID, GCS_BUCKET_NAME
 envsubst < video-generator.yaml | kubectl apply -f -
 
 echo 'Deploying video-generator to cluster...'

--- a/video-generator/src/image/image_processor.py
+++ b/video-generator/src/image/image_processor.py
@@ -25,10 +25,11 @@ logger = log.getLogger()
 
 class ImageProcessor():
 
-  def __init__(self, storage, generator, cloud_storage):
+  def __init__(self, storage, generator, cloud_storage, cloud_preview=False):
     self.storage = storage
     self.generator = generator
     self.cloud_storage = cloud_storage
+    self.cloud_preview = cloud_preview
 
   def process_task(self, row, config, preview_only=False):
 
@@ -40,7 +41,10 @@ class ImageProcessor():
       output_image = self.generate_single_image(row, config)
 
       # Uploads image to storage and retrieve the ID
-      output_id = self.storage.upload_to_preview(output_image)
+      if self.cloud_preview:
+        output_id = self.cloud_storage.upload_to_preview(output_image)
+      else:
+        output_id = self.storage.upload_to_preview(output_image)
 
       # Finally, deletes local file since it's not needed anymore
       self.storage.delete_file(output_image)

--- a/video-generator/src/main.py
+++ b/video-generator/src/main.py
@@ -38,10 +38,15 @@ logger = log.getLogger()
 def main():
     # Read environment parameters
     spreadsheet_id = os.environ.get('SPREADSHEET_ID')
+    gcs_bucket_name = os.environ.get('GCS_BUCKET_NAME')
+    cloud_preview = False
 
     if spreadsheet_id is None:
         print('Please set environment variable SPREADSHEET_ID.')
         exit(1)
+    if gcs_bucket_name:
+        cloud_preview = True
+        print(f"Saving image and video preview to Google Cloud Storage bucket named: {gcs_bucket_name}.")
 
     # Tries to retrieve token from storage each 5 minutes
     while True:
@@ -58,10 +63,10 @@ def main():
     # Dependencies
     configuration = Configuration(spreadsheet_id, credentials)
     storage = StorageHandler(configuration.get_drive_folder(), credentials)
-    cloud_storage = CloudStorageHandler(credentials)
+    cloud_storage = CloudStorageHandler(gcs_bucket_name=gcs_bucket_name)
     video_processor = VideoProcessor(
-        storage, VideoGenerator(), Uploader(credentials), cloud_storage)
-    image_processor = ImageProcessor(storage, ImageGenerator(), cloud_storage)
+        storage, VideoGenerator(), Uploader(credentials), cloud_storage, cloud_preview)
+    image_processor = ImageProcessor(storage, ImageGenerator(), cloud_storage, cloud_preview)
 
     # Handler acts as facade
     handler = EventHandler(configuration, video_processor, image_processor)

--- a/video-generator/src/video/video_processor.py
+++ b/video-generator/src/video/video_processor.py
@@ -26,11 +26,12 @@ logger = log.getLogger()
 class VideoProcessor():
     OUTPUT_VIDEO_FORMAT = '.mp4'
 
-    def __init__(self, storage, generator, uploader, cloud_storage):
+    def __init__(self, storage, generator, uploader, cloud_storage, cloud_preview=False):
         self.storage = storage
         self.generator = generator
         self.uploader = uploader
         self.cloud_storage = cloud_storage
+        self.cloud_preview = cloud_preview
 
     def process_task(self, row, config, preview_only=False):
 
@@ -43,7 +44,10 @@ class VideoProcessor():
 
             if preview_only:
                 # Uploads video to storage and retrieve the ID
-                video_id = self.storage.upload_to_preview(output_video)
+                if self.cloud_preview:
+                    video_id = self.cloud_storage.upload_to_preview(output_video)
+                else:
+                    video_id = self.storage.upload_to_preview(output_video)
             else:
                 # Uploads video to YouTube and retrieve the ID
                 video_id = self.uploader.upload_video(

--- a/video-generator/video-generator.yaml
+++ b/video-generator/video-generator.yaml
@@ -35,3 +35,5 @@ spec:
         env:
         - name: SPREADSHEET_ID
           value: $SPREADSHEET_ID
+        - name: GCS_BUCKET_NAME
+          value: $GCS_BUCKET_NAME


### PR DESCRIPTION
## Overview
This PR adds the ability to specify a Google Cloud Storage Bucket for the storage of preview assets instead of Google Drive. 

### New functions
In the installer, a new option is presented to the user to provide a GCS bucket name. If the option is left blank, we will continue storing preview assets to Google Drive. If a non-blank value is supplied, we will store preview assets to the specified GCS bucket instead.

In the PVA Template, generated assets stored in GCS can be identified by the gsutil URI prefix `gs://`, while generated assets stored in drive do not have any prefix, and is simply the ID of the Google Drive file. Having a mix of assets stored in GCS and drive in the same PVA Template is fully supported. 

When preview assets are stored in GCS, assuming the currently logged-in user has view permissions on the GCS bucket, the user will be able to download and preview assets exactly the same as if the asset was stored in Google Drive. 

## Testing
### Regression Testing
1. Install PVA with blank GCS bucket Name, generate video and upload to Youtube, ensure video is uploaded
2. Install PVA with blank GCS bucket Name, generate video to preview, ensure video is stored in drive, and preview and download functionality is working
3. Install PVA with blank GCS bucket Name, generate image to preview, ensure image is stored in drive, and download functionality is working

### New functionality Testing
4. Install PVA with supplied GCS bucket Name, generate video to preview, ensure video is stored in GCS, and preview and download functionality is working
5. Install PVA with blank GCS bucket Name, generate image to preview, ensure image is stored in GCS, and download functionality is working

## Additional notes: 
`credentials` are no longer passed to the `CloudStorageHandler` constructor in `main.py` to avoid confusion since we will always use the default GCP application credentials. This is because the passed in credentials were always being [overridden in the constructor](https://github.com/google/product_video_ads/blob/main/video-generator/src/storage/cloud_storage_handler.py#L29) due to the fact that [the credential was passed in as the first positional argument](https://github.com/google/product_video_ads/blob/main/video-generator/src/main.py#L61), when the constructor is expecting credentials to be the second positional argument. 