### PR TITLE
Updating from imagemagick version from 7.0.11.14-r0 to 7.0.11.14-r1

### DIFF
--- a/video-generator/Dockerfile
+++ b/video-generator/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7.11-alpine3.14
 
 # Unzip and ImageMagick dependencies
-RUN apk update && apk add unzip imagemagick==7.0.11.14-r0
+RUN apk update && apk add unzip imagemagick==7.0.11.14-r1
 
 # FFMPEG dependencies
 RUN apk update && apk add ffmpeg-libs==4.4.1-r0 ffmpeg==4.4.1-r0


### PR DESCRIPTION
## Description

Dockerfile is failing due to  imagemagick==7.0.11.14-r0 no longer being available via apk. The solution is to update to imagemagick==7.0.11.14-r1 since that version is available.

Error log:
```
Sending build context to Docker daemon  178.7kB
Step 1/10 : FROM python:3.7.11-alpine3.14
3.7.11-alpine3.14: Pulling from library/python
a0d0a0d46f8b: Pull complete
c11246b421be: Pull complete
7f077e365186: Pull complete
e0c8b5e7aa63: Pull complete
08feaf68e62e: Pull complete
Digest: sha256:fcf44c5aaf990b16a37f5ad9f27d98c5da8b9bf280e48fe3383820882926ddee
Status: Downloaded newer image for python:3.7.11-alpine3.14
 ---> ab6374cb8b8e
Step 2/10 : RUN apk update && apk add unzip imagemagick==7.0.11.14-r0
 ---> Running in 2d45337926fa
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
v3.14.4-13-g2b54340fa3 [https://dl-cdn.alpinelinux.org/alpine/v3.14/main]
v3.14.4-6-g7b889b7851 [https://dl-cdn.alpinelinux.org/alpine/v3.14/community]
OK: 14970 distinct packages available
ERROR: unable to select packages:
  imagemagick-7.0.11.14-r1:
    breaks: world[imagemagick=7.0.11.14-r0]
The command '/bin/sh -c apk update && apk add unzip imagemagick==7.0.11.14-r0' returned a non-zero code: 1
Error response from daemon: No such image: video-generator:latest
```

List of available imagemagick package versions via apk:
```
charlieliu@cloudshell:~/product_video_ads (charlieliu-pva-gke)$ docker image ls
REPOSITORY   TAG                 IMAGE ID       CREATED        SIZE
python       3.7.11-alpine3.14   ab6374cb8b8e   6 months ago   41.9MB
charlieliu@cloudshell:~/product_video_ads (charlieliu-pva-gke)$ docker run -it ab6374cb8b8e sh
/ # apk update
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
v3.14.4-13-g2b54340fa3 [https://dl-cdn.alpinelinux.org/alpine/v3.14/main]
v3.14.4-6-g7b889b7851 [https://dl-cdn.alpinelinux.org/alpine/v3.14/community]
OK: 14970 distinct packages available
/ # apk search imagemagick
imagemagick-perlmagick-doc-7.0.11.14-r1
imagemagick-c++-7.0.11.14-r1
imagemagick6-6.9.11.55-r0
imagemagick-doc-7.0.11.14-r1
imagemagick6-dev-6.9.11.55-r0
imagemagick-dev-7.0.11.14-r1
imagemagick-static-7.0.11.14-r1
imagemagick-zsh-completion-5.8.1-r0
imagemagick6-libs-6.9.11.55-r0
imagemagick6-c++-6.9.11.55-r0
imagemagick6-doc-6.9.11.55-r0
imagemagick-perlmagick-7.0.11.14-r1
imagemagick-libs-7.0.11.14-r1
imagemagick-7.0.11.14-r1
/ #
```

## Testing
Error went away and generated a video and image after updating imagemagick version