### PR TITLE
Adding functionality to specify custom output location when creating …

### DIFF
--- a/frontend/src/app/models/video_metadata.ts
+++ b/frontend/src/app/models/video_metadata.ts
@@ -23,6 +23,7 @@ export class VideoMetadata {
         public base_video : string,
         public products_label : string,
         public configs : Array<Config>,
+        public custom_dir : string = '',
         public description : string = '',
         public visibility : string = '',
         public date : string = new Date().toLocaleString('pt-BR')

--- a/frontend/src/app/modules/video/views/video.component.html
+++ b/frontend/src/app/modules/video/views/video.component.html
@@ -148,25 +148,38 @@
     
     <h3>What do you want to do?</h3>
 
-    <div class="added_item" [ngClass]="{'selected_box': mode == 'single' && !youtube}" (click)="select_single_video_mode()">
+    <div class="added_item" [ngClass]="{'selected_box': mode == 'single' && !youtube && !custom_dir}" (click)="select_single_video_mode()">
       <mat-icon aria-hidden="false" aria-label="video_label icon" title="video_label">video_label</mat-icon>
       <p>Create <b>one</b><br/>single asset <b>(Preview)</b></p>
     </div>
 
-    <div class="added_item" [ngClass]="{'selected_box': mode == 'bulk' && !youtube}" (click)="select_bulk_video_mode()">
+    <div class="added_item" [ngClass]="{'selected_box': mode == 'bulk' && !youtube && !custom_dir}" (click)="select_bulk_video_mode()">
       <mat-icon aria-hidden="false" aria-label="video_library icon" title="video_library">video_library</mat-icon>
       <p>Create <b>multiple</b><br/>assets in bulk <b>(Preview)</b></p>
     </div>
 
     <span *ngIf="is_base_video(base)">
-      <div class="added_item" [ngClass]="{'selected_box': mode == 'single' && youtube}" (click)="select_single_video_mode(true)">
+      <div class="added_item" [ngClass]="{'selected_box': mode == 'single' && youtube && !custom_dir}" (click)="select_single_video_mode(true)">
         <mat-icon aria-hidden="false" aria-label="video_label icon" title="video_label">ondemand_video</mat-icon>
         <p>Create <b>one</b><br/>single asset <b>(YouTube)</b></p>
       </div>
 
-      <div class="added_item" [ngClass]="{'selected_box': mode == 'bulk' && youtube}" (click)="select_bulk_video_mode(true)">
+      <div class="added_item" [ngClass]="{'selected_box': mode == 'bulk' && youtube && !custom_dir}" (click)="select_bulk_video_mode(true)">
         <mat-icon aria-hidden="false" aria-label="video_library icon" title="video_library">video_settings</mat-icon>
         <p>Create <b>multiple</b><br/>assets in bulk <b>(YouTube)</b></p>
+      </div>
+    </span>
+
+    <!-- Allow for images to be stored in custom directory -->
+    <span *ngIf="is_base_image(base)">
+      <div class="added_item" [ngClass]="{'selected_box': mode == 'single' && !youtube && custom_dir}" (click)="select_single_video_mode(false, true)">
+        <mat-icon aria-hidden="false" aria-label="panorama icon" title="video_label">panorama</mat-icon>
+        <p>Create <b>one</b><br/>image <b>(Cloud Storage)</b></p>
+      </div>
+  
+      <div class="added_item" [ngClass]="{'selected_box': mode == 'bulk' && !youtube && custom_dir}" (click)="select_bulk_video_mode(false, true)">
+        <mat-icon aria-hidden="false" aria-label="collections icon" title="video_library">collections</mat-icon>
+        <p>Create <b>multiple</b><br/>images <b>(Cloud Storage)</b></p>
       </div>
     </span>
   </div>
@@ -280,6 +293,19 @@
 
     </div>
 
+    <div *ngIf="custom_dir" class="ads-fields">
+      <!-- Name -->
+      <mat-form-field class="example-full-width">
+        <mat-label>Name</mat-label>
+        <input [(ngModel)]="video_metadata.name" placeholder="Name" matInput>
+      </mat-form-field>
+      <!-- Custom output dir -->
+      <mat-form-field class="example-full-width">
+        <mat-label>Storage Bucket</mat-label>
+        <input [(ngModel)]="custom_dir_name" placeholder="Name of storage bucket" matInput>
+      </mat-form-field>
+    </div>
+    
     <br/><br/>
 
     <button mat-stroked-button [disabled]="!is_all_filled()" (click)="add_single_video(selected_products, selected_offer_types, video_metadata)">Create Asset</button>
@@ -391,9 +417,17 @@
 
           <div>{{selected_groups.size}} selected</div>
 
+          <div *ngIf="custom_dir" class="ads-fields">
+            <!-- Custom output dir -->
+            <mat-form-field class="example-full-width">
+              <mat-label>Storage Bucket</mat-label>
+              <input [(ngModel)]="custom_dir_name" placeholder="Name of storage bucket" matInput>
+            </mat-form-field>
+          </div>
+
         <br/><br/>
 
-        <button mat-stroked-button (click)="review_create_bulk()">Review Bulk</button>
+        <button mat-stroked-button [disabled]="!is_all_filled()" (click)="review_create_bulk()">Review Bulk</button>
 
         <br/><br/>
 

--- a/video-generator/src/configuration/event_handler.py
+++ b/video-generator/src/configuration/event_handler.py
@@ -70,6 +70,7 @@ class EventHandler:
 
         config = {
             'name': metadata.get('name', 'Unnamed'),
+            'custom_dir': metadata.get('custom_dir', ''),
             'description': metadata.get('description', ''),
             'visibility': metadata.get('visibility', ''),
             'base_file': base_file_name,

--- a/video-generator/src/image/image_processor.py
+++ b/video-generator/src/image/image_processor.py
@@ -41,7 +41,9 @@ class ImageProcessor():
       output_image = self.generate_single_image(row, config)
 
       # Uploads image to storage and retrieve the ID
-      if self.cloud_preview:
+      if self._should_upload_to_directory(config):
+        output_id = self.cloud_storage.upload_to_directory(output_image, config)
+      elif self.cloud_preview:
         output_id = self.cloud_storage.upload_to_preview(output_image)
       else:
         output_id = self.storage.upload_to_preview(output_image)
@@ -83,3 +85,6 @@ class ImageProcessor():
 
   def _generate_image_name(self, input_image_file):
     return datetime.now().strftime('%Y%m%d%H%M%S') + '.' + input_image_file.split('.')[-1]
+
+  def _should_upload_to_directory(self, config): 
+    return bool(config.get('custom_dir'))


### PR DESCRIPTION
## Description

See video demo: https://drive.google.com/file/d/1HHd_N31juUMz05tZrORkQf-L2gm83jPV/view?usp=sharing

* Allows users to specify the directory and a file name prefix when generating assets
* Currently only supports images as users typically generate images directly to Youtube (extensible to video in future)
* Supports nested folder creation using Google Cloud Storage (extensible to support Google drive in future)


## Testing
* Tested for regressions by generating various Image and Videos
* New functionality is fairly well insulated. In the front-end, the feature is hidden behind two new buttons for image, and in the backend, a blank or non-existent "custom_dir" template metadata attribute disables the feature. 