### PR TITLE
Update InterfaceHelper.ts DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/app/modules/shared/InterfaceHelper.ts
+++ b/frontend/src/app/modules/shared/InterfaceHelper.ts
@@ -50,7 +50,7 @@ export class InterfaceHelper {
           }`
 
             const node = document.createElement('style');
-            node.innerHTML = styles;
+            node.innerText = styles;
             document.head.appendChild(node);
 
             loaded_fonts.add(font_name)


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks