### PR TITLE
 draggable_element.component.html DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/app/modules/shared/draggable_element/draggable_element.component.html
+++ b/frontend/src/app/modules/shared/draggable_element/draggable_element.component.html
@@ -3,7 +3,7 @@
     cdkDrag
     *ngIf="element.view_type == 'text'" 
      id="{{element.id}}" 
-     innerHTML={{element.content}} 
+     innerText={{element.content}} 
      (dblclick)="dblclick.emit({id: element.id, event: $event})"
      (click)="singleclick.emit(element)"
      (cdkDragEnded)="on_drag_element({event: $event, element: element})"


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks