### PR TITLE
fix: Make the rectangle id unique. 

### DIFF
--- a/positioning_helper/video-placements.js
+++ b/positioning_helper/video-placements.js
@@ -79,7 +79,7 @@ var VideoPlacements = /** @class */ (function () {
   };
   VideoPlacements.prototype.createRectangleElement = function (name, color, type) {
       var rect = document.createElement('div');
-      rect.id = name.replace(/\s+/g, '-').toLowerCase();
+      rect.id = name.replace(/\s+/g, '-').toLowerCase() + '-' + Date.now();  // Unique ID
       rect.classList.add('draggable');
       rect.classList.add(type.toLowerCase());
       rect.style.backgroundColor = color;


### PR DESCRIPTION
fix: Make the rectangle id unique. Otherwise, same name placeholders don't work as intended and changes to multiple placeholders update the coordinates of only a single one.