### PR TITLE
Improvements to handling of textual fields; Support audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ All columns need to have values, except _Text Font_ and those referring to a dif
   _Keep Image Ratio_: If yes, the aspect ratio will be retained, otherwise image will be scaled to provided width and height.
 - _Text Font_ (optional): font filename (including its extension)
 - _Text Size_: vertical size in pixels
-- _Text Width_: maximum characters after which the text should be wrapped using a line break
+- _Text Width_: maximum characters after which the text should be wrapped using a line break (in addition to any pre-existing line breaks in the text)
+- _Hyphenation Language_: if set to a language code (like `fr` for French or `en_US` for U.S. English, pick from [these](https://github.com/Kozea/Pyphen/tree/main/pyphen/dictionaries)), will auto-hyphenate words in lines exceeding the text width
 - _Text Alignment_: alignment inside the available width, either `left`, `center` or `right`
 - _Text Color_: color as a hexadecimal value with a leading `#`
 
@@ -253,6 +254,7 @@ The columns:
 
 - _Output AdGroup_: name of the ad group to be generated/replaced
 - _Template Video_: name of the file (uploaded to the configured bucket on Cloud Storage) to be used for the videos in this ad group
+- _Audio_: name of the file (uploaded to the configured bucket on Cloud Storage) to use as the audio track of the videos in this ad group
 - _AdGroup Type_: type of the ad group – possible values are enumerated [here](https://developers.google.com/google-ads/api/rest/reference/rest/v18/AdGroupType)
 - _Target Location_ – currently ignored, to be implemented
 - _Audience Name_ – currently ignored, to be implemented

--- a/appsscript/src/structure.ts
+++ b/appsscript/src/structure.ts
@@ -71,6 +71,7 @@ export enum ColumnName {
   textFont = 'Text Font',
   textSize = 'Text Size',
   textWidth = 'Text Width',
+  hyphenationLanguage = 'Hyphenation Language',
   url = 'URL',
   videoCreation = 'Video Creation',
 }
@@ -210,6 +211,7 @@ export const tableStructure: Partial<Record<SheetName, ColumnName[]>> = {
     ColumnName.textFont,
     ColumnName.textSize,
     ColumnName.textWidth,
+    ColumnName.hyphenationLanguage,
     ColumnName.textAlignment,
     ColumnName.textColor,
     ColumnName.removeBackground,

--- a/appsscript/src/structure.ts
+++ b/appsscript/src/structure.ts
@@ -64,6 +64,7 @@ export enum ColumnName {
   relativeVerticalAnchor = 'Relative Vertical Anchor',
   targetLocation = 'Target Location',
   templateVideo = 'Template Video',
+  templateAudio = 'Audio',
   textAlignment = 'Text Alignment',
   rotationAngle = 'Rotation Angle',
   textColor = 'Text Color',
@@ -219,6 +220,7 @@ export const tableStructure: Partial<Record<SheetName, ColumnName[]>> = {
     // If changed, reflect in Ads Script!
     ColumnName.adGroup,
     ColumnName.templateVideo,
+    ColumnName.templateAudio,
     ColumnName.adGroupType,
     ColumnName.targetLocation,
     ColumnName.audienceName,

--- a/appsscript/src/videoRequest.ts
+++ b/appsscript/src/videoRequest.ts
@@ -40,6 +40,7 @@ const elementPropertyConfig = {
       ColumnName.textFont,
       ColumnName.textAlignment,
       ColumnName.textColor,
+      ColumnName.hyphenationLanguage,
     ],
     floatProps: [ColumnName.textSize, ColumnName.textWidth],
     specialValue: {

--- a/appsscript/src/videoRequest.ts
+++ b/appsscript/src/videoRequest.ts
@@ -70,7 +70,7 @@ function getPlacement(
   const dataField = placementRecord[ColumnName.dataField];
   const elementType = placementRecord[ColumnName.elementType] as ElementType;
 
-  if (!offer[dataField]) {
+  if (offer[dataField] === undefined) {
     // Should have been caught by the 'syntax' check already.
     return [undefined, `Referenced field absent: "${dataField}"`];
   }
@@ -161,6 +161,7 @@ function getConfigForUpload(
       e => e[ColumnName.adGroup] === adGroup
     ).map(e => e[ColumnName.offerId]);
     const templateVideo = adGroupRecord[ColumnName.templateVideo];
+    const templateAudio = adGroupRecord[ColumnName.templateAudio];
     const timingRecords = configTables[SheetName.timing]!.filter(
       e => e[ColumnName.templateVideo] === templateVideo
     );
@@ -210,6 +211,7 @@ function getConfigForUpload(
     const adGroupConfig = {
       [Util.deriveFieldKey(ColumnName.adGroup)]: adGroup,
       [Util.deriveFieldKey(ColumnName.templateVideo)]: templateVideo,
+      [Util.deriveFieldKey(ColumnName.templateAudio)]: templateAudio,
       [JsonFieldName.content]: timings,
     };
     const checksum = Util.getChecksum(adGroupConfig);

--- a/service/runner/main.py
+++ b/service/runner/main.py
@@ -27,6 +27,7 @@ import logging
 import mimetypes
 import os
 import pathlib
+import pyphen
 import shutil
 import subprocess
 import tempfile
@@ -240,12 +241,14 @@ class PvaLiteRenderMessage:
         output_path: The output path to use.
         ad_group: The ad group for this render message.
         template_video: The template video for this render message.
+        template_audio: The template audio for this render message.
         content: The content for this render message.
       """
 
   output_path: str
   ad_group: str
   template_video: str
+  template_audio: Optional[str] = None
   content: Sequence[PvaLiteRenderMessageContent]
 
   def __init__(self, **kwargs):
@@ -263,6 +266,7 @@ class PvaLiteRenderMessage:
         f'output_path={self.output_path}, '
         f'ad_group={self.ad_group}, '
         f'template_video={self.template_video}, '
+        f'template_audio={self.template_audio}, '
         f'content={self.content})'
     )
 
@@ -528,6 +532,15 @@ def generate_video(message: PvaLiteRenderMessage):
         f'Template {message.template_video} does not exist in '
         f'bucket {ConfigService.GCS_BUCKET}'
     )
+
+  input_audio_path = None
+  if message.template_audio:
+    input_audio_path = StorageService.download_gcs_file(
+        filepath=message.template_audio,
+        bucket_name=ConfigService.GCS_BUCKET,
+        output_dir=output_dir,
+    )
+
   # Ensure the parent directory exists for the output path
   output_video_filename = f"{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}.mp4"
   output_video_path = pathlib.Path(
@@ -536,7 +549,11 @@ def generate_video(message: PvaLiteRenderMessage):
   output_video_path.parent.mkdir(parents=True, exist_ok=True)
 
   return process_video(
-      message.content, output_dir, input_video_path, str(output_video_path)
+      message.content,
+      output_dir,
+      input_video_path,
+      str(output_video_path),
+      input_audio_path,
   )
 
 
@@ -545,6 +562,7 @@ def process_video(
     output_dir: str,
     input_video_path: str,
     output_video_path: str,
+    input_audio_path: Optional[str] = None,
 ):
   image_or_videos_overlays = []
   text_overlays = []
@@ -609,12 +627,18 @@ def process_video(
   )
 
   # forces input audio to output
-  audio_args, audio_overlays = [], []
-  out_audio = '0:a?'
+  num_assets = len(image_or_videos_overlays) + len(text_imgs)
+  if input_audio_path:
+    audio_index = num_assets + 1
+    out_audio = f'{audio_index}:a'
+    audio_args = ['-i', input_audio_path]
+  else:
+    out_audio = '0:a?'
+    audio_args = []
 
   # assets_args
   assets_args = img_args + audio_args
-  filter_complex = img_overlays + audio_overlays
+  filter_complex = img_overlays
 
   # Group all args and runs ffmpeg
   ffmpeg_output = VideoService.run_ffmpeg(
@@ -670,45 +694,93 @@ def convert_text_overlay(
 
 
 def _wrap_text(text, characters_per_line):
-  lines = []
+  """Wraps text to fit within a specified number of characters per line.
 
+  This function splits text into lines based on character count. It uses
+  hyphenation (via Pyphen) to split words that exceed the character limit,
+  or hard splits them if they cannot be hyphenated further.
+
+  Args:
+    text: The input text to wrap.
+    characters_per_line: The maximum number of characters allowed per line.
+
+  Returns:
+    A list of strings, where each string is a wrapped line.
+  """
   if characters_per_line <= 0:
     return [text]
 
-  all_words = text.split()
-  current_line = []
-  current_line_length = 0
+  input_lines = text.split('\n')
+  output_lines = []
 
-  for word in all_words:
-    # If the current word is too long to fit on its own line, split it.
-    if len(word) > characters_per_line:
-      while len(word) > characters_per_line:
-        lines.append(word[:characters_per_line])
-        word = word[characters_per_line:]
-      lines.append(word)
-      current_line = []
-      current_line_length = 0
+  for line in input_lines:
+    if not line.strip():
+      output_lines.append('')
       continue
 
-    # If adding the current word exceeds the line limit, start a new line.
-    if current_line_length + len(word) + (
-        len(current_line) > 0
-    ) > characters_per_line:
-      lines.append(" ".join(current_line))
-      current_line = []
-      current_line_length = 0
+    all_words = line.split()
+    current_line = []
+    current_line_length = 0
+    dic = pyphen.Pyphen(lang='de')
 
-    current_line.append(word)
-    current_line_length += len(word)
+    for word in all_words:
+      # Length of line if we add this word
+      test_len = current_line_length + len(word) + (1 if current_line else 0)
+      
+      if test_len <= characters_per_line:
+        current_line.append(word)
+        current_line_length = test_len
+      else:
+        # Try to hyphenate
+        while len(word) > characters_per_line:
+          syllables = dic.inserted(word).split('-')
+          if len(syllables) <= 1:
+            # Cannot hyphenate further, hard split
+            if current_line:
+              output_lines.append(' '.join(current_line))
+              current_line = []
+              current_line_length = 0
+              
+            output_lines.append(word[:characters_per_line])
+            word = word[characters_per_line:]
+          else:
+            fitted = False
+            for i in range(len(syllables) - 1, 0, -1):
+              part = ''.join(syllables[:i]) + '-'
+              test_len = current_line_length + len(part) + (1 if current_line else 0)
+              if test_len <= characters_per_line:
+                current_line.append(part)
+                output_lines.append(' '.join(current_line))
+                word = ''.join(syllables[i:])
+                current_line = []
+                current_line_length = 0
+                fitted = True
+                break
+                
+            if not fitted:
+              if current_line:
+                output_lines.append(' '.join(current_line))
+                current_line = []
+                current_line_length = 0
+              else:
+                # Word itself doesn't fit on an empty line and no part fits
+                output_lines.append(word[:characters_per_line])
+                word = word[characters_per_line:]
 
-  # Add the last line (if any words were left).
-  if current_line:
-    lines.append(' '.join(current_line))
+        # Word is now short enough to fit on a line (or empty)
+        if current_line:
+          output_lines.append(' '.join(current_line))
+        current_line = [word] if word else []
+        current_line_length = len(word)
 
-  if not lines and text:
+    # Add the last line of this paragraph.
+    if current_line:
+      output_lines.append(' '.join(current_line))
+
+  if not output_lines and text:
     return [text]
 
-  return lines
+  return output_lines
 
 
 def remove_background(input_path):

--- a/service/runner/main.py
+++ b/service/runner/main.py
@@ -128,6 +128,7 @@ class PvaLiteRenderMessageTextPlacement(PvaLiteRenderMessagePlacement):
   text_alignment: str
   text_font: Optional[str] = None
   text_width: Optional[str] = None
+  hyphenation_language: Optional[str] = None
 
   def __init__(self, **kwargs):
     field_names = set([f.name for f in dataclasses.fields(self)])
@@ -296,7 +297,11 @@ def _get_text_dimensions(
     )
 
   # Wrap the text first to get the correct dimensions for multi-line text.
-  wrapped_lines = _wrap_text(placement.text_value, placement.text_width or 0)
+  wrapped_lines = _wrap_text(
+      placement.text_value,
+      placement.text_width or 0,
+      placement.hyphenation_language,
+  )
   multi_line_text = '\n'.join(wrapped_lines)
 
   temp_image_name = VideoService.write_temp_image(
@@ -693,7 +698,7 @@ def convert_text_overlay(
   return texts
 
 
-def _wrap_text(text, characters_per_line):
+def _wrap_text(text, characters_per_line, hyphenation_language=None):
   """Wraps text to fit within a specified number of characters per line.
 
   This function splits text into lines based on character count. It uses
@@ -703,6 +708,7 @@ def _wrap_text(text, characters_per_line):
   Args:
     text: The input text to wrap.
     characters_per_line: The maximum number of characters allowed per line.
+    hyphenation_language: Optional language code for hyphenation (e.g., 'de').
 
   Returns:
     A list of strings, where each string is a wrapped line.
@@ -721,7 +727,13 @@ def _wrap_text(text, characters_per_line):
     all_words = line.split()
     current_line = []
     current_line_length = 0
-    dic = pyphen.Pyphen(lang='de')
+    
+    dic = None
+    if hyphenation_language:
+      try:
+        dic = pyphen.Pyphen(lang=hyphenation_language)
+      except Exception as e:
+        logging.warning('Could not initialize Pyphen for language %s: %s', hyphenation_language, e)
 
     for word in all_words:
       # Length of line if we add this word
@@ -733,7 +745,7 @@ def _wrap_text(text, characters_per_line):
       else:
         # Try to hyphenate
         while len(word) > characters_per_line:
-          syllables = dic.inserted(word).split('-')
+          syllables = dic.inserted(word).split('-') if dic else [word]
           if len(syllables) <= 1:
             # Cannot hyphenate further, hard split
             if current_line:

--- a/service/runner/pva_video/pva_video.py
+++ b/service/runner/pva_video/pva_video.py
@@ -307,7 +307,7 @@ def write_temp_image(
       args += ['-size', '8000x8000']
       args += ['-gravity', 'center']
 
-    args += [('label:' + text)]  # label:@text_file_name
+    args += ['label:' + text.replace('%', '%%')]  # label:@text_file_name
 
     if use_cropped_text_fix:
       if angle and str(angle) != '0':

--- a/service/runner/requirements.txt
+++ b/service/runner/requirements.txt
@@ -20,3 +20,4 @@ google-cloud-pubsub==2.23.0
 google-cloud-storage==2.18.2
 google-api-python-client==2.86.0
 rembg[cpu]==2.0.64
+pyphen


### PR DESCRIPTION
Changes concerning the textual fields in the Offers table:
- Percentage signs no longer result in errors.
- Line breaks are now reflected in the result.
- These fields are now allowed to remain empty.
- Automatic hyphenation can be enabled.

Also, audio files can now be referenced to replace the template video's audio track.